### PR TITLE
feat(project): add support for DESIGN.md

### DIFF
--- a/helpers/github.ts
+++ b/helpers/github.ts
@@ -21,3 +21,15 @@ export const checkDesignInRepo = async ({ org, project }: any) => {
   // console.log(res)
   return !res.message ? res : { error: true }
 }
+
+export const checkDesignMdInRepo = async ({ org, project }: any) => {
+  const endpoint = `${repoEndpoint}/${org}/${project}/contents`
+  const res = await fetch(endpoint, {
+    headers: gitHubHeaders,
+  }).then((response) => response.json())
+  const designFileInResults = res.find(function (content: any) {
+    return content.name.toLowerCase() === 'design.md'
+  })
+  // console.log(res)
+  return !res.message ? [designFileInResults] : { error: true }
+}

--- a/pages/[org]/[project].tsx
+++ b/pages/[org]/[project].tsx
@@ -243,7 +243,14 @@ export default function Home() {
                     <Link
                       href={
                         !data.design.error
-                          ? `https://github.com/${data.result.metadata.full_name}/tree/main/.design`
+                          ? `https://github.com/${
+                              data.result.metadata.full_name
+                            }/tree/main/${
+                              data.result.metadata.hasDesign &&
+                              data.result.metadata.designType === 'folder'
+                                ? '.design'
+                                : ''
+                            }`
                           : '#'
                       }
                       target="_blank"
@@ -256,7 +263,14 @@ export default function Home() {
                       >
                         <FolderOpenIcon size={16} />
                         <Paragraph>
-                          <strong>.design/</strong>
+                          <strong>
+                            .
+                            {data.result.metadata.hasDesign &&
+                            data.result.metadata.designType === 'folder'
+                              ? 'design'
+                              : ''}
+                            /
+                          </strong>
                         </Paragraph>
                       </GridItem>
                     </Link>
@@ -290,7 +304,12 @@ export default function Home() {
                             <FolderStructureItem
                               key={i}
                               type={item.type}
-                              link={`https://github.com/${org}/${project}/tree/main/.design/${item.name}`}
+                              link={`https://github.com/${org}/${project}/tree/main/${
+                                data.result.metadata.hasDesign &&
+                                data.result.metadata.designType === 'folder'
+                                  ? '.design'
+                                  : ''
+                              }/${item.name}`}
                             >
                               {item.name}
                             </FolderStructureItem>

--- a/pages/api/check/[org]/[project].tsx
+++ b/pages/api/check/[org]/[project].tsx
@@ -18,7 +18,7 @@ export default async function handler(req: NextRequest) {
   if (!ghProject.error) {
     projectIsValid = true
   } else {
-    console.log('no gh repo', org, project)
+    // console.log('no gh repo', org, project)
   }
 
   return new Response(projectIsValid ? '{success:200}' : '{error:404}', {

--- a/pages/api/og/[org]/[project].tsx
+++ b/pages/api/og/[org]/[project].tsx
@@ -15,7 +15,7 @@ export default async function handler(req: NextRequest) {
   const parsedProject = await getProject({ key: `${org}/${project}` })
 
   const result = parsedProject.result
-  console.log(result)
+  // console.log(result)
   return new ImageResponse(
     result.metadata ? (
       <div

--- a/pages/api/shield/[org]/[project].tsx
+++ b/pages/api/shield/[org]/[project].tsx
@@ -34,7 +34,7 @@ export default async function handler(req: NextRequest) {
         value: JSON.stringify({ date: Date.now(), ipData, geoData }),
       })
     } else {
-      console.log('no gh repo', org, project)
+      // console.log('no gh repo', org, project)
     }
   } else {
     projectIsValid = true

--- a/pages/api/shieldsio/[org]/[project].tsx
+++ b/pages/api/shieldsio/[org]/[project].tsx
@@ -45,7 +45,7 @@ export default async function handler(req: NextRequest) {
         value: JSON.stringify({ date: Date.now(), ipData, geoData }),
       })
     } else {
-      console.log('no gh repo', org, project)
+      // console.log('no gh repo', org, project)
     }
   } else {
     projectIsValid = true


### PR DESCRIPTION
## Pull request description 

Closes #31 

## Before

- We did rely on a `.design` folder in the repo

## After

- Users can either use a `.design` folder or a `DESIGN.md` in the root of their repo

## Checklist (choose what happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] updated the docs
- [ ] added a test
